### PR TITLE
Cache correctly scoped dependencies' tgz files

### DIFF
--- a/bin/npm-proxy-cache-startup.sh
+++ b/bin/npm-proxy-cache-startup.sh
@@ -1,0 +1,6 @@
+#! /bin/sh
+
+PIDFILE=$1
+/home/ubuntu/npm-proxy-cache/node_modules/npm-proxy-cache/bin/npm-proxy-cache -s /home/ubuntu/npm-proxy-cache/cached_data -p 8085 --ttl 3600 -e --internal-port 8086 &
+PID=$!
+echo $PID>$PIDFILE

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -80,22 +80,26 @@ exports.powerup = function(opts) {
 };
 
 function isTgzCacheUsable(requestPath, cachePath, urlHost) {
-  var name = path.basename(requestPath),
+  var urlParts = url.parse(requestPath),
     log = exports.log;
     
   log.debug("Start verifying tgz: " + requestPath);
   
   // check md5 sum of a file
-  // Examples of names:
-  //  double-ended-queue-2.1.0-0.tgz
-  //  double-ended-queue-2.1.0.tgz
-  //  dateformat-1.0.2-1.2.3.tgz
-  //  jju-1.3.0.tgz
-  var match = name.match(/(.+?)-(\d+?\.\d+?\.\d+?(?:.*?))\.tgz/);
+  // Examples of paths:
+  //  /@angular/compiler/-/compiler-2.0.0.tgz
+  //  /dateformat/-/dateformat-1.0.8-1.2.3.tgz
+  //  /double-ended-queue/-/double-ended-queue-2.1.0-0.tgz
+  //  /double-ended-queue/-/double-ended-queue-0.9.7.tgz
+  //  /jju/-/jju-1.3.0.tgz  
+  var match = urlParts.path.match(/^\/(.*)\/-\/.*?(\d+?\.\d+?\.\d+?(?:.*?))\.tgz/);
   if (match && match[1] && match[2]) {
-    log.debug("Name of plugin: " + match[1] + ", version is " + match[2]);
+    var pluginName = match[1],
+      pluginVersion = match[2];
 
-    var requestUrl = urlHost + "/" + match[1],
+    log.debug("Name of plugin: " + pluginName + ", version is " + pluginVersion);
+
+    var requestUrl = urlHost + "/" + pluginName,
       cache = exports.cache,
       fullPath = cache.getPath(requestUrl).full;
 
@@ -113,11 +117,11 @@ function isTgzCacheUsable(requestPath, cachePath, urlHost) {
         // TODO:
         // Possible improvement is to execute `let content = childProcess.execSync(npm view match[1])` and save the file in the cache
         // fs.writeFileSync(fullPath, JSON.stringify(JSON.parse(content)))        
-        var npmViewCommand = "npm view " + match[1] + "@" + match[2] + " dist.shasum";
+        var npmViewCommand = "npm view " + pluginName + "@" + pluginVersion + " dist.shasum";
         log.debug("Execute " + npmViewCommand);
         expectedShasum = (childProcess.execSync(npmViewCommand, { timeout: 10000 }) || '').toString().trim();
       } catch (err) {
-        log.info("Unable to get data for " + cachePath.full + " from npm. Tgz cannot be verified, return it to the client, so it's npm will verify the shasum.")
+        log.info("Unable to get data for " + cachePath.full + " from npm. Tgz cannot be verified, return it to the client, so its npm will verify the shasum.")
         log.debug("Error is: ", err);
 
         return true;
@@ -125,7 +129,7 @@ function isTgzCacheUsable(requestPath, cachePath, urlHost) {
     } else {
       var jsonData = JSON.parse(fs.readFileSync(fullPath));
       expectedShasum = jsonData && jsonData.versions && 
-        jsonData.versions[match[2]] && jsonData.versions[match[2]].dist && jsonData.versions[match[2]].dist.shasum;
+        jsonData.versions[pluginVersion] && jsonData.versions[pluginVersion].dist && jsonData.versions[pluginVersion].dist.shasum;
     }
     
     var actualShasum = hashFiles.sync({ files: [cachePath.full], noGlob: true });

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -99,7 +99,7 @@ function isTgzCacheUsable(requestPath, cachePath, urlHost) {
 
     log.debug("Name of plugin: " + pluginName + ", version is " + pluginVersion);
 
-    var requestUrl = urlHost + "/" + pluginName,
+    var requestUrl = urlHost + "/" + pluginName.replace(/\//, "%2f"),
       cache = exports.cache,
       fullPath = cache.getPath(requestUrl).full;
 
@@ -150,7 +150,7 @@ exports.httpHandler = function(req, res) {
     schema = Boolean(req.client.pair) ? 'https' : 'http',
     urlHost = schema + '://' + req.headers['host'],
     dest = urlHost + path;
-  
+
   log.debug("httpHandler called");
   
   var params = {


### PR DESCRIPTION
The logic for caching .tgz files does not work for scoped dependencies.
It works by getting name and version from the url. For normal packages urls are:
- https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz
  But for scoped dependencies they are:
- https://registry.npmjs.org/@angular/core/-/core-2.0.0.tgz

Use url.parse to correctly identify the name and version of the package and be able to cache the .tgz forever.
