### PR TITLE
Use control file to populate options object

### DIFF
--- a/bin/npm-proxy-cache
+++ b/bin/npm-proxy-cache
@@ -21,6 +21,7 @@ program
   .option('-l, --log-path [path]', 'Log path')
   .option('-m, --internal-port [port]',
     'HTTPs port to use for internal proxying "MITM" server (mandatory on Windows systems)')
+  .option('-c, --control-file [file]', 'Control file that contines keys for controlling the configuration.' )
   .parse(process.argv);
 
 require('../lib/proxy').powerup(program);

--- a/bin/npm-proxy-cache-startup.sh
+++ b/bin/npm-proxy-cache-startup.sh
@@ -1,6 +1,0 @@
-#! /bin/sh
-
-PIDFILE=$1
-/home/ubuntu/npm-proxy-cache/node_modules/npm-proxy-cache/bin/npm-proxy-cache -s /home/ubuntu/npm-proxy-cache/cached_data -p 8085 --ttl 3600 -e --internal-port 8086 &
-PID=$!
-echo $PID>$PIDFILE

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -8,7 +8,8 @@ var http = require('http'),
   request = require('request'),
   log4js = require('log4js'),
   hashFiles = require('hash-files'),
-  childProcess = require('child_process');
+  childProcess = require('child_process'),
+  _ = require("lodash");
   Cache = require('./cache');
 
 // To avoid 'DEPTH_ZERO_SELF_SIGNED_CERT' error on some setups
@@ -27,6 +28,28 @@ var mitmAddress;
 exports.powerup = function(opts) {
 
   exports.opts = opts || {};
+  
+  if (opts.controlFile) {
+    // Read the options from the control file directly
+    var fullPath = path.resolve(opts.controlFile);
+    if (fs.existsSync(fullPath)) {
+ 
+      try {
+        // Remove UTF8 BOM Header
+        var dataFromControlFile = (fs.readFileSync(fullPath) || "").toString().replace(/^\uFEFF/, ""),
+          optionsFromFile = JSON.parse(dataFromControlFile);
+          
+        // Overwrite each option from file in the opts object.
+        _.each(optionsFromFile, function(value, key) {      
+          opts[key] = value;
+        });
+        
+      } catch(err) {
+        // Disregard the error, looks like the file is not correct.
+        console.error("Error while working with control file: ", fullPath, " Error is: ", err);
+      }
+    }
+  }
 
   var options = {
     key: fs.readFileSync(__dirname + '/../cert/dummy.key', 'utf8'),

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "commander": "^2.8.1",
     "hash-files": "1.1.1",
+    "lodash": "4.16.2",
     "log4js": "^0.6.26",
     "mkdirp": "^0.5.1",
     "request": "^2.61.0"


### PR DESCRIPTION
The module parses command line options in order to modify it's behavior, for example where should be the log file, should the logging be verbose, on which port to start, what's the host, etc.
However parsing them from the command line is difficult to use the same package on different machines with different configurations. So add -c option that will be used to pass a file with configuration.
The file should be just json, containing the supported options. Any option from file will overwrite the option passed on the command line. Example content is:

``` JSON
{
    "logPath": "./test1",
    "verbose": true
}

```

This way the logs will go to ./test1 file and the mode will be verbose.

Remove the shell script from .bin directory - we do not need it anymore.

Use lodash as... it's lodash, just use it.
