### PR TITLE
Do not break process when error is raised in cache.meta

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -28,22 +28,22 @@ var mitmAddress;
 exports.powerup = function(opts) {
 
   exports.opts = opts || {};
-  
+
   if (opts.controlFile) {
     // Read the options from the control file directly
     var fullPath = path.resolve(opts.controlFile);
     if (fs.existsSync(fullPath)) {
- 
+
       try {
         // Remove UTF8 BOM Header
         var dataFromControlFile = (fs.readFileSync(fullPath) || "").toString().replace(/^\uFEFF/, ""),
           optionsFromFile = JSON.parse(dataFromControlFile);
-          
+
         // Overwrite each option from file in the opts object.
-        _.each(optionsFromFile, function(value, key) {      
+        _.each(optionsFromFile, function(value, key) {
           opts[key] = value;
         });
-        
+
       } catch(err) {
         // Disregard the error, looks like the file is not correct.
         console.error("Error while working with control file: ", fullPath, " Error is: ", err);
@@ -105,16 +105,16 @@ exports.powerup = function(opts) {
 function isTgzCacheUsable(requestPath, cachePath, urlHost) {
   var urlParts = url.parse(requestPath),
     log = exports.log;
-    
+
   log.debug("Start verifying tgz: " + requestPath);
-  
+
   // check md5 sum of a file
   // Examples of paths:
   //  /@angular/compiler/-/compiler-2.0.0.tgz
   //  /dateformat/-/dateformat-1.0.8-1.2.3.tgz
   //  /double-ended-queue/-/double-ended-queue-2.1.0-0.tgz
   //  /double-ended-queue/-/double-ended-queue-0.9.7.tgz
-  //  /jju/-/jju-1.3.0.tgz  
+  //  /jju/-/jju-1.3.0.tgz
   var match = urlParts.path.match(/^\/(.*)\/-\/.*?(\d+?\.\d+?\.\d+?(?:.*?))\.tgz/);
   if (match && match[1] && match[2]) {
     var pluginName = match[1],
@@ -130,16 +130,13 @@ function isTgzCacheUsable(requestPath, cachePath, urlHost) {
       log.info("Path: " + cachePath.full + " for " + requestPath + " does not exist. It will be downloaded.");
       return false;
     }
-    
+
     var expectedShasum;
-    if (!fs.existsSync(fullPath)) {
-      // TODO:
-      // Possible improvement is to call the requestUrl and cache the result. This way the cachePath.full will work.
-      log.info("Path: " + fullPath + " for " + requestUrl + " does not exist. ");
+    var tryGetShasumFromNpmViewCommand = function() {
       try {
         // TODO:
         // Possible improvement is to execute `let content = childProcess.execSync(npm view match[1])` and save the file in the cache
-        // fs.writeFileSync(fullPath, JSON.stringify(JSON.parse(content)))        
+        // fs.writeFileSync(fullPath, JSON.stringify(JSON.parse(content)))
         var npmViewCommand = "npm view " + pluginName + "@" + pluginVersion + " dist.shasum";
         log.debug("Execute " + npmViewCommand);
         expectedShasum = (childProcess.execSync(npmViewCommand, { timeout: 10000 }) || '').toString().trim();
@@ -148,21 +145,37 @@ function isTgzCacheUsable(requestPath, cachePath, urlHost) {
         log.debug("Error is: ", err);
 
         return true;
-      }  
+      }
+    };
+
+    if (fs.existsSync(fullPath)) {
+      try {
+        var jsonData = JSON.parse(fs.readFileSync(fullPath));
+        expectedShasum = jsonData && jsonData.versions &&
+          jsonData.versions[pluginVersion] && jsonData.versions[pluginVersion].dist && jsonData.versions[pluginVersion].dist.shasum;
+      } catch (err) {
+        log.debug("Error is: ", err);
+        log.info("Error while checking json file: " + fullPath + ". It looks like it's not valid json. Remove it from cache.");
+        fs.unlinkSync(fullPath);
+      }
     } else {
-      var jsonData = JSON.parse(fs.readFileSync(fullPath));
-      expectedShasum = jsonData && jsonData.versions && 
-        jsonData.versions[pluginVersion] && jsonData.versions[pluginVersion].dist && jsonData.versions[pluginVersion].dist.shasum;
+      // TODO:
+      // Possible improvement is to call the requestUrl and cache the result. This way the cachePath.full will work.
+      log.info("Path: " + fullPath + " for " + requestUrl + " does not exist. ");
     }
-    
+
+    if (!expectedShasum && tryGetShasumFromNpmViewCommand()) {
+      return true;
+    }
+
     var actualShasum = hashFiles.sync({ files: [cachePath.full], noGlob: true });
-    
+
     log.debug("Expected shasum: " + expectedShasum);
     log.debug("Actual shasum:   " + actualShasum);
-    
+
     return expectedShasum === actualShasum;
   }
-  
+
   return true;
 }
 
@@ -175,7 +188,7 @@ exports.httpHandler = function(req, res) {
     dest = urlHost + path;
 
   log.debug("httpHandler called");
-  
+
   var params = {
     url: dest,
     rejectUnauthorized: false
@@ -189,19 +202,6 @@ exports.httpHandler = function(req, res) {
     return bypass(req, res, params);
 
   cache.meta(dest, function(err, meta) {
-    if (err)
-      throw err;
-    
-    var p = cache.getPath(dest),
-      isTgz = require("path").extname(dest) === ".tgz";
-
-    if ((meta.status === Cache.FRESH && !isTgz) || (isTgz && isTgzCacheUsable(dest, p, urlHost)) )
-      return respondWithCache(dest, cache, meta, res);
-
-    log.debug('Cache file:', p.rel);
-
-    log.warn('direct', dest);
-
     var onResponse = function(err, response) {
       // don't save responses with codes other than 200
       if (!err && response.statusCode === 200) {
@@ -227,6 +227,19 @@ exports.httpHandler = function(req, res) {
         res.end(err ? err.toString() : 'Status ' + response.statusCode + ' returned');
       }
     }
+
+    if (err)
+      return onResponse(err, null);
+
+    var p = cache.getPath(dest),
+      isTgz = require("path").extname(dest) === ".tgz";
+
+    if ((meta.status === Cache.FRESH && !isTgz) || (isTgz && isTgzCacheUsable(dest, p, urlHost)) )
+      return respondWithCache(dest, cache, meta, res);
+
+    log.debug('Cache file:', p.rel);
+
+    log.warn('direct', dest);
 
     var r = request(params);
     r.on('response', onResponse.bind(null, null));
@@ -323,32 +336,32 @@ function respondWithCache(dest, cache, meta, res) {
   res.setHeader('Content-Type', meta.type);
   res.setHeader('Connection', 'keep-alive');
   res.setHeader('X-Cache-Hit', 'true');
-  
+
   var destStream = cache.read(dest);
   destStream.on('end', function() {
     log.debug('Dest stream on end: ', dest);
   });
-  
+
   destStream.on('finish', function() {
     log.debug('Dest stream on finish: ', dest);
   });
-  
+
   destStream.on('close', function() {
     log.debug('Dest stream on close: ', dest);
   });
-  
+
   res.on('end', function() {
     log.debug('Res stream on end: ', dest);
   });
-  
+
   res.on('finish', function() {
     log.debug('Res stream on finish: ', dest);
   });
-  
+
   res.on('close', function() {
     log.debug('Res stream on close: ', dest);
-  }); 
-  
+  });
+
   return destStream.pipe(res);
 }
 

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -9,7 +9,8 @@ var http = require('http'),
   log4js = require('log4js'),
   hashFiles = require('hash-files'),
   childProcess = require('child_process'),
-  _ = require("lodash");
+  _ = require("lodash"),
+  Readable = require('stream').Readable;
   Cache = require('./cache');
 
 // To avoid 'DEPTH_ZERO_SELF_SIGNED_CERT' error on some setups
@@ -206,10 +207,32 @@ exports.httpHandler = function(req, res) {
       // don't save responses with codes other than 200
       if (!err && response.statusCode === 200) {
         log.debug('Write to cache: ', dest);
-        var file = cache.write(dest);
-        r.pipe(file);
-        r.pipe(res, {end: false});
 
+        if (response.headers['content-type'] === "application/json") {
+          var data = "";
+          r.on("data", function(chunk) {
+            data+=chunk.toString();
+          });
+
+          r.on("end", function() {
+            try {
+              JSON.parse(data);
+              var readableStream = new Readable();
+              var file = cache.write(dest);
+              readableStream.pipe(file);
+              readableStream.push(data);
+              readableStream.push(null);
+            } catch (err) {
+              log.error("Incorrect result from: " + params.url + ". File will not be cached.");
+              log.debug("Error is: ", err);
+            }
+          });
+        } else {
+          var file = cache.write(dest);
+          r.pipe(file);
+        }
+
+        r.pipe(res, {end: false});
       } else {
         // serve expired cache if user wants so
         if (exports.opts.expired && meta.status === Cache.EXPIRED)


### PR DESCRIPTION
In some cases we call the callback passed to cache.meta with error object.
This callback is inside proxy.js's http handler and it automatically raises the error.
This error is unhandled, so the process breaks.

Instead of doing this, just return the error. This way the process should remain alive and the npm client should retry the operation.

Also when trying to check the shasum of a .tgz, we may find incorrect json in our cached data. Remove the file in such case and return the .tgz file, so it will be verified from the client's npm.
