### PR TITLE
Remove lock correctly

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -46,6 +46,7 @@ function Cache(opts) {
       if (self.locks[key]) {
         remainingTime -= 1000;
         if (remainingTime < 0) {
+          self.removeLock(key);
           cb(new Error("Waited too long to get lock for " + key));
         }
         return setTimeout(wait, 1000);
@@ -85,6 +86,15 @@ function Cache(opts) {
     });
 
     return file;
+  };
+
+
+  this.removeLock = function(key) {
+    var locks = this.locks;
+
+    if (Object.hasOwnProperty(locks, key)) {
+      delete(locks[key]);
+    }
   };
 
 

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -225,6 +225,7 @@ exports.httpHandler = function(req, res) {
             } catch (err) {
               log.error("Incorrect result from: " + params.url + ". File will not be cached.");
               log.debug("Error is: ", err);
+              cache.removeLock(dest);
             }
           });
         } else {


### PR DESCRIPTION
In some cases, when error occurs, we do not remove the lock of file, so all requests for it will hang.
Remove it in these cases.
