### PR TITLE
Fix TypeError: Cannot read property 'valueOf' of undefined

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -355,7 +355,7 @@ function bypass(req, res, params) {
 function respondWithCache(dest, cache, meta, res) {
   var log = exports.log;
   log.info('cache', dest);
-  log.debug('size: %s, type: "%s", ctime: %d', meta.size, meta.type, meta.ctime.valueOf());
+  log.debug('size: %s, type: "%s", ctime: %d', meta.size, meta.type, meta.ctime && meta.ctime.valueOf());
   res.setHeader('Content-Length', meta.size);
   res.setHeader('Content-Type', meta.type);
   res.setHeader('Connection', 'keep-alive');


### PR DESCRIPTION
Fix `TypeError: Cannot read property 'valueOf' of undefined` that is raised in some cases when evaluating parameters for debug message that is not shown to the user.
