### PR TITLE
Fix caching of .tgz from custom registry

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -46,7 +46,7 @@ exports.powerup = function(opts) {
         });
 
       } catch(err) {
-        // Disregard the error, looks like the file is not correct.
+        // Disregard the error, looks like the file is not VALID.
         console.error("Error while working with control file: ", fullPath, " Error is: ", err);
       }
     }
@@ -129,7 +129,7 @@ function isTgzCacheUsable(requestPath, cachePath, urlHost) {
 
     if (!fs.existsSync(cachePath.full)) {
       log.info("Path: " + cachePath.full + " for " + requestPath + " does not exist. It will be downloaded.");
-      return false;
+      return "INVALID";
     }
 
     var expectedShasum;
@@ -145,7 +145,7 @@ function isTgzCacheUsable(requestPath, cachePath, urlHost) {
         log.info("Unable to get data for " + cachePath.full + " from npm. Tgz cannot be verified, return it to the client, so its npm will verify the shasum.")
         log.debug("Error is: ", err);
 
-        return true;
+        return "VALID";
       }
     };
 
@@ -166,7 +166,7 @@ function isTgzCacheUsable(requestPath, cachePath, urlHost) {
     }
 
     if (!expectedShasum && tryGetShasumFromNpmViewCommand()) {
-      return true;
+      return "VALID";
     }
 
     var actualShasum = hashFiles.sync({ files: [cachePath.full], noGlob: true });
@@ -174,10 +174,10 @@ function isTgzCacheUsable(requestPath, cachePath, urlHost) {
     log.debug("Expected shasum: " + expectedShasum);
     log.debug("Actual shasum:   " + actualShasum);
 
-    return expectedShasum === actualShasum;
+    return expectedShasum === actualShasum ? "VALID" : "INVALID"
   }
 
-  return true;
+  return "OTHER_REGISTRY";
 }
 
 exports.httpHandler = function(req, res) {
@@ -223,7 +223,7 @@ exports.httpHandler = function(req, res) {
               readableStream.push(data);
               readableStream.push(null);
             } catch (err) {
-              log.error("Incorrect result from: " + params.url + ". File will not be cached.");
+              log.error("InVALID result from: " + params.url + ". File will not be cached.");
               log.debug("Error is: ", err);
               cache.removeLock(dest);
             }
@@ -257,8 +257,9 @@ exports.httpHandler = function(req, res) {
 
     var p = cache.getPath(dest),
       isTgz = require("path").extname(dest) === ".tgz";
+      isTgzCacheUsableStatus = isTgz && isTgzCacheUsable(dest, p, urlHost);
 
-    if ((meta.status === Cache.FRESH && !isTgz) || (isTgz && isTgzCacheUsable(dest, p, urlHost)) )
+    if ((meta.status === Cache.FRESH && (!isTgz || isTgzCacheUsableStatus === "OTHER_REGISTRY")) || isTgzCacheUsableStatus === "VALID")
       return respondWithCache(dest, cache, meta, res);
 
     log.debug('Cache file:', p.rel);


### PR DESCRIPTION
Currrent code expects all .tgz files to be from registry.npmjs.org and when it is changed, the code fails to use .tgz and proxy process dies.